### PR TITLE
Parallelise G1 Point Deserialisation 

### DIFF
--- a/srs/.gitignore
+++ b/srs/.gitignore
@@ -1,1 +1,3 @@
 target
+extracted.data
+serialised_pp.data

--- a/srs/Cargo.lock
+++ b/srs/Cargo.lock
@@ -356,6 +356,7 @@ dependencies = [
  "dusk-plonk",
  "hex",
  "merlin",
+ "num_cpus",
  "rand",
 ]
 

--- a/srs/Cargo.toml
+++ b/srs/Cargo.toml
@@ -12,3 +12,4 @@ dusk-plonk = { git = "https://github.com/dusk-network/plonk", tag = "v0.3.5" }
 hex = "0.4.3"
 rand = "0.7.0"
 merlin = "2.0.0"
+num_cpus = "1.13.0"


### PR DESCRIPTION
I noticed, byte array to structured `G1Affine` deserialisation can be easily parallelised due to absence of any dependency. Previously it used to be computed in single thread, requiring >300s.

```bash
$ sysctl -n machdep.cpu.brand_string

Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz
```

```bash
$ cargo run extracted.data
hash: 6e3f4b98e6c205d0efa5abc917dd03e28864016df380936fa4e9865595c5d69863eff93e8badf8e6b8c8cbfd5ab3a415ef7ba50b86e124bd9bfcd3f9aab67124
deserialised G1s, in 342.413588969s
public params of max degree: 65535	[OBTAINED]
```

When using 8 threads, runtime is greatly reduced to ~100s. ⭐️

```bash
$ cargo run extracted.data
hash: 6e3f4b98e6c205d0efa5abc917dd03e28864016df380936fa4e9865595c5d69863eff93e8badf8e6b8c8cbfd5ab3a415ef7ba50b86e124bd9bfcd3f9aab67124
deserialising G1s, using 8 CPUs
deserialised G1s, in 103.788464974s
public params of max degree: 65535	[OBTAINED]
```

> Implementation uses **M**ultiple **P**roducer **S**ingle **C**onsumer channel for communication in between master & workers. 